### PR TITLE
Enhancement Video - Increase visible Scanline defaults

### DIFF
--- a/mednafen/src/pce/pce.cpp
+++ b/mednafen/src/pce/pce.cpp
@@ -1081,8 +1081,8 @@ static const MDFNSetting PCESettings[] =
 {
   { "pce.input.multitap", MDFNSF_EMU_STATE | MDFNSF_UNTRUSTED_SAFE, gettext_noop("Enable multitap(TurboTap) emulation."), NULL, MDFNST_BOOL, "1" },
 
-  { "pce.slstart", MDFNSF_NOFLAGS, gettext_noop("First rendered scanline."), NULL, MDFNST_UINT, "0", "0", "239" },
-  { "pce.slend", MDFNSF_NOFLAGS, gettext_noop("Last rendered scanline."), NULL, MDFNST_UINT, "239", "0", "239" },
+  { "pce.slstart", MDFNSF_NOFLAGS, gettext_noop("First rendered scanline."), NULL, MDFNST_UINT, "0", "0", "241" },
+  { "pce.slend", MDFNSF_NOFLAGS, gettext_noop("Last rendered scanline."), NULL, MDFNST_UINT, "241", "0", "241" },
 
   { "pce.h_overscan", MDFNSF_NOFLAGS, gettext_noop("Show horizontal overscan area."), NULL, MDFNST_BOOL, "0" },
 

--- a/mednafen/src/pce/pce.cpp
+++ b/mednafen/src/pce/pce.cpp
@@ -1081,8 +1081,8 @@ static const MDFNSetting PCESettings[] =
 {
   { "pce.input.multitap", MDFNSF_EMU_STATE | MDFNSF_UNTRUSTED_SAFE, gettext_noop("Enable multitap(TurboTap) emulation."), NULL, MDFNST_BOOL, "1" },
 
-  { "pce.slstart", MDFNSF_NOFLAGS, gettext_noop("First rendered scanline."), NULL, MDFNST_UINT, "4", "0", "239" },
-  { "pce.slend", MDFNSF_NOFLAGS, gettext_noop("Last rendered scanline."), NULL, MDFNST_UINT, "235", "0", "239" },
+  { "pce.slstart", MDFNSF_NOFLAGS, gettext_noop("First rendered scanline."), NULL, MDFNST_UINT, "0", "0", "239" },
+  { "pce.slend", MDFNSF_NOFLAGS, gettext_noop("Last rendered scanline."), NULL, MDFNST_UINT, "239", "0", "239" },
 
   { "pce.h_overscan", MDFNSF_NOFLAGS, gettext_noop("Show horizontal overscan area."), NULL, MDFNST_BOOL, "0" },
 

--- a/mednafen/src/pce/vce.cpp
+++ b/mednafen/src/pce/vce.cpp
@@ -464,10 +464,10 @@ INLINE void VCE::SyncSub(int32 clocks)
     else
      scanline++;
 
-    if(scanline == 14 + 240)
+    if(scanline == 14 + 240) // does this need to be 242 as well?
      FrameDone = true;
 
-    if((scanline == 14 + 240) || (scanline == 123))
+    if((scanline == 14 + 242) || (scanline == 125))
     {
      HuCPU.Exit();
     }


### PR DESCRIPTION
This sets the default number of visible scanlines to 240.