### PR TITLE
Enhancement Video - Enable Horizontal Overscan

### DIFF
--- a/mednafen/src/pce/pce.cpp
+++ b/mednafen/src/pce/pce.cpp
@@ -1084,7 +1084,7 @@ static const MDFNSetting PCESettings[] =
   { "pce.slstart", MDFNSF_NOFLAGS, gettext_noop("First rendered scanline."), NULL, MDFNST_UINT, "4", "0", "239" },
   { "pce.slend", MDFNSF_NOFLAGS, gettext_noop("Last rendered scanline."), NULL, MDFNST_UINT, "235", "0", "239" },
 
-  { "pce.h_overscan", MDFNSF_NOFLAGS, gettext_noop("Show horizontal overscan area."), NULL, MDFNST_BOOL, "0" },
+  { "pce.h_overscan", MDFNSF_NOFLAGS, gettext_noop("Show horizontal overscan area."), NULL, MDFNST_BOOL, "1" },
 
   { "pce.mouse_sensitivity", MDFNSF_NOFLAGS, gettext_noop("Emulated mouse sensitivity."), NULL, MDFNST_FLOAT, "0.50", NULL, NULL, NULL, PCEINPUT_SettingChanged },
   { "pce.disable_softreset", MDFNSF_NOFLAGS, gettext_noop("If set, when RUN+SEL are pressed simultaneously, disable both buttons temporarily."), NULL, MDFNST_BOOL, "0", NULL, NULL, NULL, PCEINPUT_SettingChanged },


### PR DESCRIPTION
Enable displaying the Horizontal Overscan area for accurate Resolution switching in games and the 240pSuite and other utility tools.

With the ORIGINAL default `pce.h_overscan 0` setting, not showing the accurate resolution as expected and as visible on real hardware:

![Screen_Dimension_Test-0000](https://user-images.githubusercontent.com/95596143/147572530-2181e1ef-4942-4733-b1d7-b8bc9e8513ba.png)

With the PROPOSED `pce.h_overscan 1` setting it is now showing the accurate resolution widths as expected and in use on real hardware:

![Screen_Dimension_Test-0001](https://user-images.githubusercontent.com/95596143/147572744-c2a4d9d9-92cd-4f4e-a85a-966599090ec5.png)

