### PR TITLE
Default setting for interpolation should be 'off', not bilnear interp…

### DIFF
--- a/mednafen/src/drivers/video.cpp
+++ b/mednafen/src/drivers/video.cpp
@@ -346,7 +346,7 @@ void Video_MakeSettings(void)
    else if(!mr)
     default_videoip = "0";
    else
-    default_videoip = "1";
+    default_videoip = "0";
 
    sysname = (const char *)MDFNSystems[i]->shortname;
   }


### PR DESCRIPTION
…olation (see issue #19 )

Bilinear interpolation is not a suitable default; change default back to no interploation.  (Of course, the option is still available).