### PR TITLE
Fix CD head seek timing for PCE ( #4 )

### DIFF
--- a/mednafen/src/Makefile.in
+++ b/mednafen/src/Makefile.in
@@ -619,10 +619,11 @@ am__mednafen_SOURCES_DIST = debug.cpp error.cpp mempatcher.cpp \
 	cdrom/lec.cpp cdrom/CDUtility.cpp cdrom/CDInterface.cpp \
 	cdrom/CDInterface_MT.cpp cdrom/CDInterface_ST.cpp \
 	cdrom/CDAccess.cpp cdrom/CDAccess_Image.cpp \
-	cdrom/CDAccess_CCD.cpp cdrom/CDAFReader.cpp \
-	cdrom/CDAFReader_Vorbis.cpp cdrom/CDAFReader_MPC.cpp \
-	cdrom/CDAFReader_FLAC.cpp cdrom/CDAFReader_PCM.cpp \
-	cdrom/scsicd.cpp sound/Blip_Buffer.cpp sound/Stereo_Buffer.cpp \
+	cdrom/CDAccess_CCD.cpp cdrom/seektime_pce.cpp \
+	cdrom/CDAFReader.cpp cdrom/CDAFReader_Vorbis.cpp \
+	cdrom/CDAFReader_MPC.cpp cdrom/CDAFReader_FLAC.cpp \
+	cdrom/CDAFReader_PCM.cpp cdrom/scsicd.cpp \
+	sound/Blip_Buffer.cpp sound/Stereo_Buffer.cpp \
 	sound/Fir_Resampler.cpp sound/WAVRecord.cpp sound/okiadpcm.cpp \
 	sound/DSPUtility.cpp sound/SwiftResampler.cpp \
 	sound/OwlResampler.cpp net/Net.cpp net/Net_POSIX.cpp \
@@ -971,7 +972,8 @@ am_mednafen_OBJECTS = debug.$(OBJEXT) error.$(OBJEXT) \
 	cdrom/CDInterface.$(OBJEXT) cdrom/CDInterface_MT.$(OBJEXT) \
 	cdrom/CDInterface_ST.$(OBJEXT) cdrom/CDAccess.$(OBJEXT) \
 	cdrom/CDAccess_Image.$(OBJEXT) cdrom/CDAccess_CCD.$(OBJEXT) \
-	cdrom/CDAFReader.$(OBJEXT) cdrom/CDAFReader_Vorbis.$(OBJEXT) \
+	cdrom/seektime_pce.$(OBJEXT) cdrom/CDAFReader.$(OBJEXT) \
+	cdrom/CDAFReader_Vorbis.$(OBJEXT) \
 	cdrom/CDAFReader_MPC.$(OBJEXT) $(am__objects_39) \
 	cdrom/CDAFReader_PCM.$(OBJEXT) cdrom/scsicd.$(OBJEXT) \
 	$(am__objects_40) sound/Fir_Resampler.$(OBJEXT) \
@@ -1042,8 +1044,8 @@ am__depfiles_remade = ./$(DEPDIR)/ExtMemStream.Po \
 	cdrom/$(DEPDIR)/crc32.Po cdrom/$(DEPDIR)/galois.Po \
 	cdrom/$(DEPDIR)/l-ec.Po cdrom/$(DEPDIR)/lec.Po \
 	cdrom/$(DEPDIR)/recover-raw.Po cdrom/$(DEPDIR)/scsicd.Po \
-	cheat_formats/$(DEPDIR)/gb.Po cheat_formats/$(DEPDIR)/psx.Po \
-	cheat_formats/$(DEPDIR)/snes.Po \
+	cdrom/$(DEPDIR)/seektime_pce.Po cheat_formats/$(DEPDIR)/gb.Po \
+	cheat_formats/$(DEPDIR)/psx.Po cheat_formats/$(DEPDIR)/snes.Po \
 	compress/$(DEPDIR)/ArchiveReader.Po \
 	compress/$(DEPDIR)/DecompressFilter.Po \
 	compress/$(DEPDIR)/GZFileStream.Po \
@@ -1706,24 +1708,24 @@ mednafen_SOURCES = debug.cpp error.cpp mempatcher.cpp settings.cpp \
 	cdrom/lec.cpp cdrom/CDUtility.cpp cdrom/CDInterface.cpp \
 	cdrom/CDInterface_MT.cpp cdrom/CDInterface_ST.cpp \
 	cdrom/CDAccess.cpp cdrom/CDAccess_Image.cpp \
-	cdrom/CDAccess_CCD.cpp cdrom/CDAFReader.cpp \
-	cdrom/CDAFReader_Vorbis.cpp cdrom/CDAFReader_MPC.cpp \
-	$(am__append_62) cdrom/CDAFReader_PCM.cpp cdrom/scsicd.cpp \
-	$(am__append_63) sound/Fir_Resampler.cpp sound/WAVRecord.cpp \
-	sound/okiadpcm.cpp sound/DSPUtility.cpp \
-	sound/SwiftResampler.cpp sound/OwlResampler.cpp net/Net.cpp \
-	$(am__append_64) $(am__append_65) string/escape.cpp \
-	string/string.cpp video/surface.cpp video/convert.cpp \
-	video/tblur.cpp video/Deinterlacer.cpp \
-	video/Deinterlacer_Simple.cpp video/Deinterlacer_Blend.cpp \
-	video/resize.cpp video/video.cpp video/primitives.cpp \
-	video/png.cpp video/text.cpp video/font-data.cpp \
-	video/font-data-18x18.c video/font-data-12x13.c \
-	resampler/resample.c cputest/cputest.c $(am__append_66) \
-	$(am__append_67) cheat_formats/gb.cpp cheat_formats/psx.cpp \
-	cheat_formats/snes.cpp compress/ArchiveReader.cpp \
-	compress/ZIPReader.cpp compress/GZFileStream.cpp \
-	compress/DecompressFilter.cpp \
+	cdrom/CDAccess_CCD.cpp cdrom/seektime_pce.cpp \
+	cdrom/CDAFReader.cpp cdrom/CDAFReader_Vorbis.cpp \
+	cdrom/CDAFReader_MPC.cpp $(am__append_62) \
+	cdrom/CDAFReader_PCM.cpp cdrom/scsicd.cpp $(am__append_63) \
+	sound/Fir_Resampler.cpp sound/WAVRecord.cpp sound/okiadpcm.cpp \
+	sound/DSPUtility.cpp sound/SwiftResampler.cpp \
+	sound/OwlResampler.cpp net/Net.cpp $(am__append_64) \
+	$(am__append_65) string/escape.cpp string/string.cpp \
+	video/surface.cpp video/convert.cpp video/tblur.cpp \
+	video/Deinterlacer.cpp video/Deinterlacer_Simple.cpp \
+	video/Deinterlacer_Blend.cpp video/resize.cpp video/video.cpp \
+	video/primitives.cpp video/png.cpp video/text.cpp \
+	video/font-data.cpp video/font-data-18x18.c \
+	video/font-data-12x13.c resampler/resample.c cputest/cputest.c \
+	$(am__append_66) $(am__append_67) cheat_formats/gb.cpp \
+	cheat_formats/psx.cpp cheat_formats/snes.cpp \
+	compress/ArchiveReader.cpp compress/ZIPReader.cpp \
+	compress/GZFileStream.cpp compress/DecompressFilter.cpp \
 	compress/ZstdDecompressFilter.cpp compress/ZLInflateFilter.cpp \
 	hash/md5.cpp hash/sha1.cpp hash/sha256.cpp hash/crc.cpp \
 	$(am__append_70)
@@ -3225,6 +3227,8 @@ cdrom/CDAccess_Image.$(OBJEXT): cdrom/$(am__dirstamp) \
 	cdrom/$(DEPDIR)/$(am__dirstamp)
 cdrom/CDAccess_CCD.$(OBJEXT): cdrom/$(am__dirstamp) \
 	cdrom/$(DEPDIR)/$(am__dirstamp)
+cdrom/seektime_pce.$(OBJEXT): cdrom/$(am__dirstamp) \
+	cdrom/$(DEPDIR)/$(am__dirstamp)
 cdrom/CDAFReader.$(OBJEXT): cdrom/$(am__dirstamp) \
 	cdrom/$(DEPDIR)/$(am__dirstamp)
 cdrom/CDAFReader_Vorbis.$(OBJEXT): cdrom/$(am__dirstamp) \
@@ -3536,6 +3540,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@cdrom/$(DEPDIR)/lec.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@cdrom/$(DEPDIR)/recover-raw.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@cdrom/$(DEPDIR)/scsicd.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@cdrom/$(DEPDIR)/seektime_pce.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@cheat_formats/$(DEPDIR)/gb.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@cheat_formats/$(DEPDIR)/psx.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@cheat_formats/$(DEPDIR)/snes.Po@am__quote@ # am--include-marker
@@ -5645,6 +5650,7 @@ distclean: distclean-recursive
 	-rm -f cdrom/$(DEPDIR)/lec.Po
 	-rm -f cdrom/$(DEPDIR)/recover-raw.Po
 	-rm -f cdrom/$(DEPDIR)/scsicd.Po
+	-rm -f cdrom/$(DEPDIR)/seektime_pce.Po
 	-rm -f cheat_formats/$(DEPDIR)/gb.Po
 	-rm -f cheat_formats/$(DEPDIR)/psx.Po
 	-rm -f cheat_formats/$(DEPDIR)/snes.Po
@@ -6193,6 +6199,7 @@ maintainer-clean: maintainer-clean-recursive
 	-rm -f cdrom/$(DEPDIR)/lec.Po
 	-rm -f cdrom/$(DEPDIR)/recover-raw.Po
 	-rm -f cdrom/$(DEPDIR)/scsicd.Po
+	-rm -f cdrom/$(DEPDIR)/seektime_pce.Po
 	-rm -f cheat_formats/$(DEPDIR)/gb.Po
 	-rm -f cheat_formats/$(DEPDIR)/psx.Po
 	-rm -f cheat_formats/$(DEPDIR)/snes.Po

--- a/mednafen/src/cdrom/Makefile.am.inc
+++ b/mednafen/src/cdrom/Makefile.am.inc
@@ -2,6 +2,7 @@ mednafen_SOURCES	+=	cdrom/crc32.cpp cdrom/galois.cpp cdrom/l-ec.cpp cdrom/recove
 mednafen_SOURCES	+=	cdrom/CDUtility.cpp
 mednafen_SOURCES	+=	cdrom/CDInterface.cpp cdrom/CDInterface_MT.cpp cdrom/CDInterface_ST.cpp
 mednafen_SOURCES	+=	cdrom/CDAccess.cpp cdrom/CDAccess_Image.cpp cdrom/CDAccess_CCD.cpp
+mednafen_SOURCES	+=	cdrom/seektime_pce.cpp
 
 mednafen_SOURCES	+=	cdrom/CDAFReader.cpp
 mednafen_SOURCES	+=	cdrom/CDAFReader_Vorbis.cpp

--- a/mednafen/src/cdrom/scsicd-pce-commands.inc
+++ b/mednafen/src/cdrom/scsicd-pce-commands.inc
@@ -6,6 +6,7 @@
 static void DoNEC_PCE_SAPSP(const uint8 *cdb)
 {
  uint32 new_read_sec_start;
+ float seekms;
 
  //printf("Set audio start: %02x %02x %02x %02x %02x %02x %02x\n", cdb[9], cdb[1], cdb[2], cdb[3], cdb[4], cdb[5], cdb[6]);
  switch (cdb[9] & 0xc0)
@@ -47,6 +48,15 @@ static void DoNEC_PCE_SAPSP(const uint8 *cdb)
  read_sec = read_sec_start = new_read_sec_start;
  read_sec_end = toc.tracks[100].lba;
 
+ seekms = get_pce_cd_seek_ms(head_pos, read_sec);
+ //printf("From sec %6.6X to %6.6X (SAPSP), ms = %.2f\n", head_pos, read_sec, seekms);
+ CDDASeekTimer = (uint64)(System_Clock * seekms / 1000);
+ CDAudioDelay  = (uint64)(System_Clock * 260 / 1000);
+
+ if (CDDASeekTimer > CDAudioDelay)
+   CDDASeekTimer -= CDAudioDelay;
+ else
+   CDAudioDelay = 0;
 
  cdda.CDDAReadPos = 588;
 
@@ -62,7 +72,7 @@ static void DoNEC_PCE_SAPSP(const uint8 *cdb)
  if(read_sec < toc.tracks[100].lba)
   Cur_CDIF->HintReadSector(read_sec);
 
- SendStatusAndMessage(STATUS_GOOD, 0x00);
+ DelaySendStatusAndMessage(STATUS_GOOD, 0x00);
  CDIRQCallback(SCSICD_IRQ_DATA_TRANSFER_DONE);
 }
 
@@ -127,6 +137,7 @@ static void DoNEC_PCE_SAPEP(const uint8 *cdb)
 		   break;
  }
 
+ //printf("(SAPEP)\n");
  SendStatusAndMessage(STATUS_GOOD, 0x00);
 }
 

--- a/mednafen/src/cdrom/seektime_pce.cpp
+++ b/mednafen/src/cdrom/seektime_pce.cpp
@@ -1,0 +1,121 @@
+/*
+ ============================================================================
+ Name        : seektime.c
+ Author      : Dave Shadoff
+ Version     :
+ Copyright   : (C) 2018 Dave Shadoff
+ Description : Program to determine seek time, based on start and end sector numbers
+ ============================================================================
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+
+typedef struct sector_group {
+		int		sec_per_revolution;
+		int		sec_start;
+		int		sec_end;
+		float	rotation_ms;
+		float	rotation_vsync;
+} sector_group;
+
+#define NUM_SECTOR_GROUPS	14
+
+sector_group sector_list[NUM_SECTOR_GROUPS] = {
+	{ 10,	0,		12572,	133.47,	 8.00 },
+	{ 11,	12573,	30244,	146.82,	 8.81 },		// Except for the first and last groups,
+	{ 12,	30245,	49523,	160.17,	 9.61 },		// there are 1606.5 tracks in each range
+	{ 13,	49524,	70408,	173.51,	10.41 },
+	{ 14,	70409,	92900,	186.86,	11.21 },
+	{ 15,	92901,	116998,	200.21,	12.01 },
+	{ 16,	116999,	142703,	213.56,	12.81 },
+	{ 17,	142704,	170014,	226.90,	13.61 },
+	{ 18,	170015,	198932,	240.25,	14.42 },
+	{ 19,	198933,	229456,	253.60,	15.22 },
+	{ 20,	229457,	261587,	266.95,	16.02 },
+	{ 21,	261588,	295324,	280.29,	16.82 },
+	{ 22,	295325,	330668,	293.64,	17.62 },
+	{ 23,	330669,	333012,	306.99,	18.42 }
+};
+
+
+static int find_sector_group(int sector_num)
+{
+	int i;
+	int group_index = 0;
+
+	for (i = 0; i < NUM_SECTOR_GROUPS; i++)
+	{
+		if ((sector_num >= sector_list[i].sec_start) && (sector_num <= sector_list[i].sec_end))
+		{
+			group_index = i;
+			break;
+		}
+	}
+	return group_index;
+}
+
+float get_pce_cd_seek_ms(int start_sector, int target_sector)
+{
+	int start_index;
+	int target_index;
+
+	float track_difference;
+	float milliseconds = 0;
+
+	// First, we identify which group the start and end are in
+	start_index = find_sector_group(start_sector);
+	target_index = find_sector_group(target_sector);
+
+	// Now we find the track difference
+	//
+	// Note: except for the first and last sector groups, all groups are 1606.48 tracks per group.
+	//
+	if (target_index == start_index)
+	{
+		track_difference = (float)(abs(target_sector - start_sector) / sector_list[target_index].sec_per_revolution);
+	}
+	else if (target_index > start_index)
+	{
+		track_difference = (sector_list[start_index].sec_end - start_sector) / sector_list[start_index].sec_per_revolution;
+		track_difference += (target_sector - sector_list[target_index].sec_start) / sector_list[target_index].sec_per_revolution;
+		track_difference += (1606.48 * (target_index - start_index - 1));
+	}
+	else // start_index > target_index
+	{
+		track_difference = (start_sector - sector_list[start_index].sec_start) / sector_list[start_index].sec_per_revolution;
+		track_difference += (sector_list[target_index].sec_end - target_sector) / sector_list[target_index].sec_per_revolution;
+		track_difference += (1606.48 * (start_index - target_index - 1));
+	}
+
+	// Now, we use the algorithm to determine how long to wait
+	if (abs(target_sector - start_sector) <= 3)
+	{
+		milliseconds = (2 * 1000 / 60);
+	}
+	else if (abs(target_sector - start_sector) < 7)
+	{
+		milliseconds = (9 * 1000 / 60) + (float)(sector_list[target_index].rotation_ms * 0.75);
+	}
+	else if (track_difference <= 80)
+	{
+		milliseconds = (17 * 1000 / 60) + (float)(sector_list[target_index].rotation_ms * 0.75);
+	}
+	else if (track_difference <= 160)
+	{
+		milliseconds = (22 * 1000 / 60) + (float)(sector_list[target_index].rotation_ms * 0.75);
+	}
+	else if (track_difference <= 644)
+	{
+		milliseconds = (22 * 1000 / 60) + (float)(sector_list[target_index].rotation_ms * 0.75) + (float)((track_difference - 161) * 16.66 / 80);
+	}
+	else
+	{
+		milliseconds = (36 * 1000 / 60) + (float)(sector_list[target_index].rotation_ms * 0.5) + (float)((track_difference - 644) * 16.66 / 195);
+	}
+
+	return milliseconds;
+}
+

--- a/mednafen/src/cdrom/seektime_pce.h
+++ b/mednafen/src/cdrom/seektime_pce.h
@@ -1,0 +1,12 @@
+/*
+ ============================================================================
+ Name        : seektime.h
+ Author      : Dave Shadoff
+ Version     :
+ Copyright   : (C) 2022 Dave Shadoff
+ Description : Program to determine seek time, based on start and end sector numbers
+ ============================================================================
+ */
+
+extern float get_pce_cd_seek_ms(int start_sector, int target_sector);
+


### PR DESCRIPTION
Fix timing.  This involved:
- keeping a unified head position based on least read position
- detecting data read (mode 6) and pce audio read transactions, and identifying positioning delay based on tables created through earlier research
- delaying the status response from the CDROM unit for audio seek (until after seek was complete)
- further delaying audio playback by roughly 250ms after CDROM status response
Note: Delays were only implemented for PC Engine; other machines will require measurement and their own logic for implementation.