### PR TITLE
Add option to stop execution on Alt-D to enter debugger

### DIFF
--- a/mednafen/src/drivers/main.cpp
+++ b/mednafen/src/drivers/main.cpp
@@ -176,7 +176,8 @@ static const MDFNSetting DriverSettings[] =
   { "sound.rate", MDFNSF_NOFLAGS, gettext_noop("Specifies the sound playback rate, in sound frames per second(\"Hz\")."), NULL, MDFNST_UINT, "48000", "22050", "192000"},
 
   #ifdef WANT_DEBUGGER
-  { "debugger.autostepmode", MDFNSF_NOFLAGS, gettext_noop("Automatically go into the debugger's step mode after a game is loaded."), NULL, MDFNST_BOOL, "1" },
+  { "debugger.autostepmode", MDFNSF_NOFLAGS, gettext_noop("Automatically go into the debugger's step mode after a game is loaded."), NULL, MDFNST_BOOL, "0" },
+  { "debugger.haltondebug", MDFNSF_NOFLAGS, gettext_noop("Halt (enter step mode) when Alt-D is pressed to enter debug mode."), NULL, MDFNST_BOOL, "1" },
   #endif
 
   { "osd.message_display_time", MDFNSF_NOFLAGS, gettext_noop("Length of time, in milliseconds, to display internal status and error messages"), gettext_noop("Time lengths less than 100ms are recommended against unless you understand you may miss important non-fatal error messages, and that the input configuration process may become unusable."), MDFNST_UINT, "2500", "0", "15000" },


### PR DESCRIPTION
Also, set the default to start the game directly rather than enter the debugger (change default setting in mednafen.cfg)