### PR TITLE
Add in git repo commit tag and build date to the MDFN Version notation

### DIFF
--- a/mednafen/configure
+++ b/mednafen/configure
@@ -4393,7 +4393,7 @@ $as_echo "$ac_cv_safe_to_define___extensions__" >&6; }
 #
 # Avoid trailing and leading zeroes in the decimal version components to avoid confusing not-so-learned people.
 #
-MEDNAFEN_VERSION='1.29.0.pceDev-1.0'
+MEDNAFEN_VERSION="1.29.0.pceDev-1.0 (`git log -1 --format=format:%h`) built on `date` "
 MEDNAFEN_VERSION_NUMERIC=0x00102900
 #                        0xJJJnnnRR
 


### PR DESCRIPTION
Add in git repo commit/tag and build date to the MDFN Version notation for easier tracking of what was built and when.

i.e. 1.29.0.pceDev-1.0 (6d1e241) built on Sat May 21 20:48:06 PDT 2022 