### PR TITLE
Add feature to step by scanline or display frame ( #74 )

### DIFF
--- a/mednafen/src/drivers/debugger.h
+++ b/mednafen/src/drivers/debugger.h
@@ -36,6 +36,17 @@ void Debugger_GT_ForceSteppingMode(void);
 void Debugger_GT_ForceStepIfStepping(void); // For synchronizations with save state loading and reset/power toggles.
 void Debugger_GT_SyncDisToPC(void);	// Synch disassembly address to current PC/IP/whatever.
 
+void Debugger_GT_SetHSync(void);
+void Debugger_GT_ResetHSync(void);
+bool Debugger_GT_HSyncIsSet(void);
+
+void Debugger_GT_SetVSync(void);
+void Debugger_GT_ResetVSync(void);
+bool Debugger_GT_VSyncIsSet(void);
+
+bool IsVSYNCBreakPoint(void);
+bool IsHSYNCBreakPoint(void);
+
 // Must be called in a specific place in the game thread's execution path.
 void Debugger_GTR_PassBlit(void);
 
@@ -57,6 +68,18 @@ static INLINE bool Debugger_GT_IsInSteppingMode(void) { return(false); }
 static INLINE void Debugger_GT_ForceSteppingMode(void) { }
 static INLINE void Debugger_GT_ForceStepIfStepping(void) { }
 static INLINE void Debugger_GT_SyncDisToPC(void) { }
+
+static INLINE void Debugger_GT_SetHSync(void) {  }
+static INLINE void Debugger_GT_ResetHSync(void) { }
+static INLINE bool Debugger_GT_HSyncSet(void) { return(false); }
+
+static INLINE void Debugger_GT_SetVSync(void) { }
+static INLINE void Debugger_GT_ResetVSync(void) { }
+static INLINE bool Debugger_GT_VSyncSet(void) { return(false); }
+
+static INLINE bool IsVSYNCBreakPoint(void) { }
+static INLINE bool IsHSYNCBreakPoint(void) { }
+
 static INLINE void Debugger_GTR_PassBlit(void) { }
 static INLINE void Debugger_MT_DrawToScreen(const MDFN_PixelFormat& pf, signed screen_w, signed screen_h) { }
 static INLINE bool Debugger_IsActive(void) { return(false); }

--- a/mednafen/src/hw_video/huc6270/vdc.h
+++ b/mednafen/src/hw_video/huc6270/vdc.h
@@ -517,7 +517,7 @@ class VDC
 	int HPhase, VPhase;
 	int HNextEvent;
 	int32 HPhaseCounter, VPhaseCounter;
-	int32 Scanline_from_VSYNC;
+	uint32 Scanline_from_VSYNC;
 
 	int32 sprite_cg_fetch_counter;
 

--- a/mednafen/src/pce/debug.cpp
+++ b/mednafen/src/pce/debug.cpp
@@ -63,6 +63,10 @@
 #define EX_GETFNT       0xE060
 #define EX_VSYNC        0xE07B
 
+extern bool IsHSYNCBreakPoint();
+extern bool IsVSYNCBreakPoint();
+
+
 namespace MDFN_IEN_PCE
 {
 
@@ -378,7 +382,7 @@ static bool CPUHandler(uint32 PC)
 
  PCE_InDebug++;
 
- FoundBPoint = TestPCBP(PC) | TestOpBP(HuCPU.PeekLogical(PC));
+ FoundBPoint = TestPCBP(PC) | TestOpBP(HuCPU.PeekLogical(PC)) | IsVSYNCBreakPoint() | IsHSYNCBreakPoint();
 
  if(NeedExecSimu)
   TestRWBP();

--- a/mednafen/src/pce/vce.cpp
+++ b/mednafen/src/pce/vce.cpp
@@ -32,6 +32,9 @@
 #include "pcecd.h"
 #include <trio/trio.h>
 
+extern bool DebugHSyncFlag;
+extern bool DebugVSyncFlag;
+
 namespace MDFN_IEN_PCE
 {
 
@@ -482,9 +485,13 @@ INLINE void VCE::SyncSub(int32 clocks)
     {
      scanline = 0;
      framenum++;
+     DebugVSyncFlag = true;
     }
     else
+    {
      scanline++;
+     DebugHSyncFlag = true;
+    }
 
     if(scanline == 14 + 240) // does this need to be 242 as well?
      FrameDone = true;


### PR DESCRIPTION
Whereas 's' in debug mode steps by an opcode,
<SHIFT>-s will now step by a scan line
<CTRL>-s will now step by a display frame