### PR TITLE
Approximate effects of MAWR slicing ( #5 , #56 )

### DIFF
--- a/mednafen/src/drivers/main.cpp
+++ b/mednafen/src/drivers/main.cpp
@@ -1226,12 +1226,26 @@ void DoFrameAdvance(void)
 
 static int GameLoopPaused = 0;
 
+void InitScanLine(uint32 y)
+{
+ static int entry = 0;
+
+ if (entry > 2)  // don't copy if not yet properly initialized
+ {
+   uint32 pitch32 = SoftFB[SoftFB_BackBuffer ^ 1].surface->pitch32;    // refresh new frame with (frame-1) data (overwrite residual frame-2 data)
+   SoftFB[SoftFB_BackBuffer].lw[y] = SoftFB[SoftFB_BackBuffer ^ 1].lw[y];
+   memcpy(&SoftFB[SoftFB_BackBuffer].surface->pixels[y*pitch32], &SoftFB[SoftFB_BackBuffer ^ 1].surface->pixels[y*pitch32], (pitch32 * sizeof(uint32)));
+ }
+ else
+   entry++;
+}
+
 void DebuggerFudge(void)
 {
  const uint32 WaitMS = 10;
  uint32 wt = Time::MonoMS() + WaitMS;
 
- MDFND_Update(SoftFB_BackBuffer ^ 1, nullptr, 0);
+ MDFND_Update(SoftFB_BackBuffer, nullptr, 0);
 
  wt -= Time::MonoMS();
 
@@ -1277,7 +1291,7 @@ static int GameLoop(void *arg)
 	 NeedFrameAdvance = false;
 	 //
 	 //
-	 SoftFB[SoftFB_BackBuffer].lw[0] = ~0;
+	 //SoftFB[SoftFB_BackBuffer].lw[0] = ~0;   // This messes up "current frame" display; let's see if it is useful at all before deleting
 
 	 //
 	 //

--- a/mednafen/src/drivers/main.h
+++ b/mednafen/src/drivers/main.h
@@ -59,6 +59,7 @@ void DoRunNormal(void);
 void DoFrameAdvance(void);
 bool IsInFrameAdvance(void);
 
+void InitScanLine(uint32 y);
 void DebuggerFudge(void);
 
 MDFN_HIDE extern volatile int GameThreadRun;

--- a/mednafen/src/hw_video/huc6270/vdc.h
+++ b/mednafen/src/hw_video/huc6270/vdc.h
@@ -272,6 +272,10 @@ class VDC
 	void DoVBIRQTest(void);
 	void HDS_Start(void);
 
+	bool IsActiveDisplay(void);
+	uint32 ActiveDisplayPenaltyCycles = 0;   // to simulate the MAWR time-slot 
+	bool MAWRPhase = false;   // to simulate the MAWR time-slot 
+
 	void StateExtra(LEPacker &sl_packer, bool load);
 	void StateAction(StateMem *sm, const unsigned load, const bool data_only, const char *sname);
 

--- a/mednafen/src/pce/vce.cpp
+++ b/mednafen/src/pce/vce.cpp
@@ -35,6 +35,8 @@
 extern bool DebugHSyncFlag;
 extern bool DebugVSyncFlag;
 
+extern void InitScanLine(uint32 y);
+
 namespace MDFN_IEN_PCE
 {
 
@@ -235,8 +237,8 @@ void VCE::StartFrame(MDFN_Surface *surface, MDFN_Rect *DisplayRect, int32 *LineW
   DisplayRect->y = 14 + MDFN_GetSettingUI("pce.slstart");
   DisplayRect->h = MDFN_GetSettingUI("pce.slend") - MDFN_GetSettingUI("pce.slstart") + 1;
 
-  for(int y = 0; y < 263; y++)
-   LineWidths[y] = 0;
+  for(uint32 y = 0; y < 262; y++) // This frame has residuals from two frames ago; refresh to only one frame ago
+   InitScanLine(y);
 
   pitch32 = surface->pitch32;
   fb = surface->pixels;
@@ -415,12 +417,15 @@ INLINE void VCE::SyncSub(int32 clocks)
        for(int32 s_i = 0; s_i < dot_clock_ratio; s_i++)
        {
         scanline_out_ptr[pixel_offset & 2047] = pix;
+        scanline_out_ptr[(pixel_offset & 2047) + 1] = boundbox_color;  // see the location of the raster scan
+        scanline_out_ptr[(pixel_offset & 2047) + 2] = boundbox_color;
         pixel_offset++;
        }
       }
       else
       {
-       scanline_out_ptr[pixel_offset & 2047] = pix;
+       scanline_out_ptr[(pixel_offset & 2047) + 1] = boundbox_color;  // see the location of the raster scan
+       scanline_out_ptr[(pixel_offset & 2047) + 2] = boundbox_color;
        pixel_offset++;
       }
      }
@@ -440,6 +445,8 @@ INLINE void VCE::SyncSub(int32 clocks)
          pix = color_table_cache[pixel_buffer[0][i] & 0x3FF];
 
         scanline_out_ptr[pixel_offset & 2047] = pix;
+        scanline_out_ptr[(pixel_offset & 2047) + 1] = boundbox_color;  // see the location of the raster scan
+        scanline_out_ptr[(pixel_offset & 2047) + 2] = boundbox_color;
         pixel_offset++;
        }
       }
@@ -454,6 +461,8 @@ INLINE void VCE::SyncSub(int32 clocks)
        else
         pix = color_table_cache[pixel_buffer[0][i] & 0x3FF];
        scanline_out_ptr[pixel_offset & 2047] = pix;
+       scanline_out_ptr[(pixel_offset & 2047) + 1] = boundbox_color;  // see the location of the raster scan
+       scanline_out_ptr[(pixel_offset & 2047) + 2] = boundbox_color;
        pixel_offset++;
       }
      }

--- a/mednafen/src/pce/vce.cpp
+++ b/mednafen/src/pce/vce.cpp
@@ -77,6 +77,16 @@ bool VCE::WS_Hook(int32 vdc_cycles)
   ret = false;
  }
 
+ for(unsigned chip = 0; chip < chip_count; chip++)
+ {
+  while (vdc[chip].ActiveDisplayPenaltyCycles > 0)  // try to make accesses to ActiveDisplayPenaltyCycles as atomic as possible
+  {
+   to_steal++;
+   vdc[chip].ActiveDisplayPenaltyCycles--;
+  }
+ }
+
+
  if(to_steal > 0)
  {
   HuCPU.StealCycles(to_steal);


### PR DESCRIPTION
Mednafen does not respect the time-slicing of the MAWR (Memory Access Width Register) register, which arbitrates between accesses for the CPU versus those used for video display. This Pull Request doesn't accurately fix that, but it does approximate correct timing more closely.

During Active Display, CPU shares access with display based on MAWR timing; when a CPU access is made when it's not the CPU's 'slot', there is a wait state introduced.

This PR adds penalty cycles on a 50% ratio basis during active scan, rather than emulating the exact timing of the time slots, so it is only an approximation.

It also does not impose penalty cycles during HSYNC, when sprite prefetch would take place, so this will also continue to be an inaccuracy for the time being.