### PR TITLE
Add frame (or line) advance to all debugger windows ( #94 )

### DIFF
--- a/mednafen/src/drivers/debugger.cpp
+++ b/mednafen/src/drivers/debugger.cpp
@@ -48,10 +48,10 @@ static unsigned int WhichMode; // 0 = normal, 1 = gfx, 2 = memory
 
 static bool NeedPCBPToggle;
 static int NeedStep;	// 0 =, 1 = , 2 = 
-static int NeedRun;
+int NeedRun;
 static bool InSteppingMode;
-static bool WaitForVSYNC = false;
-static bool WaitForHSYNC = false;
+bool WaitForVSYNC = false;
+bool WaitForHSYNC = false;
 
 static std::vector<uint32> PCBreakPoints;
 static std::string ReadBreakpoints, IOReadBreakpoints, AuxReadBreakpoints;
@@ -1466,7 +1466,12 @@ static void CPUCallback(uint32 PC, bool bpoint)
  if((NeedStep == 2 && !InSteppingMode) || bpoint)
  {
   if(bpoint)
-   SetActive(true, 0);
+  {
+   if ((WaitForHSYNC) || (WaitForVSYNC))
+    SetActive(true, WhichMode);
+   else
+    SetActive(true, 0);
+  }
 
   DisAddr = PC;
   DisCOffs = 0xFFFFFFFF;
@@ -1507,11 +1512,11 @@ static void CPUCallback(uint32 PC, bool bpoint)
 }
 
 INLINE void Debugger_GT_SetHSync(void) { DebugHSyncFlag = true; }
-INLINE void Debugger_GT_ResetHSync(void) { DebugHSyncFlag = false; }
+void Debugger_GT_ResetHSync(void) { DebugHSyncFlag = false; }
 INLINE bool Debugger_GT_HSyncIsSet(void) { return(DebugHSyncFlag); }
 
 INLINE void Debugger_GT_SetVSync(void) { DebugVSyncFlag = true; }
-INLINE void Debugger_GT_ResetVSync(void) { DebugVSyncFlag = false; };
+void Debugger_GT_ResetVSync(void) { DebugVSyncFlag = false; };
 INLINE bool Debugger_GT_VSyncIsSet(void) { return(DebugVSyncFlag); }
 
 // Function called from game thread, input driver code.

--- a/mednafen/src/drivers/gfxdebugger.cpp
+++ b/mednafen/src/drivers/gfxdebugger.cpp
@@ -24,6 +24,12 @@
 #include "debugger.h"
 #include <trio/trio.h>
 
+extern bool WaitForVSYNC;
+extern bool WaitForHSYNC;
+extern int NeedRun;
+extern void Debugger_GT_ResetHSync(void);
+extern void Debugger_GT_ResetVSync(void);
+
 static MDFN_Surface *gd_surface = NULL;
 static bool IsActive = 0;
 static const char *LayerNames[16];
@@ -247,6 +253,26 @@ int GfxDebugger_Event(const SDL_Event *event)
 	LayerPBN[CurLayer]++;
 	RedoSGD();
 	break;
+
+   case SDLK_s:
+	if(event->key.keysym.mod & KMOD_CTRL)
+        {
+         Debugger_GT_ResetVSync();
+         Debugger_GT_ResetHSync();
+         WaitForHSYNC = false;
+         WaitForVSYNC = true;
+         NeedRun = true;
+        }
+	else if(event->key.keysym.mod & KMOD_SHIFT)
+        {
+         Debugger_GT_ResetVSync();
+         Debugger_GT_ResetHSync();
+         WaitForHSYNC = true;
+         WaitForVSYNC = false;
+         NeedRun = true;
+        }
+        break;
+
   }
  }
  return true;

--- a/mednafen/src/drivers/logdebugger.cpp
+++ b/mednafen/src/drivers/logdebugger.cpp
@@ -31,6 +31,13 @@
 
 #define LOG_NUMLINES	43
 
+extern bool WaitForVSYNC;
+extern bool WaitForHSYNC;
+extern int NeedRun;
+extern void Debugger_GT_ResetHSync(void);
+extern void Debugger_GT_ResetVSync(void);
+
+
 typedef struct
 {
  char *type;
@@ -248,6 +255,25 @@ int LogDebugger_Event(const SDL_Event *event)
 
 	 case SDLK_PAGEDOWN: ChangePos(LOG_NUMLINES); 
 			     break;
+
+	 case SDLK_s:
+	      if(event->key.keysym.mod & KMOD_CTRL)
+	      {
+	       Debugger_GT_ResetVSync();
+	       Debugger_GT_ResetHSync();
+	       WaitForHSYNC = false;
+	       WaitForVSYNC = true;
+	       NeedRun = true;
+	      }
+	      else if(event->key.keysym.mod & KMOD_SHIFT)
+	      {
+	       Debugger_GT_ResetVSync();
+	       Debugger_GT_ResetHSync();
+	       WaitForHSYNC = true;
+	       WaitForVSYNC = false;
+	       NeedRun = true;
+	      }
+	      break;
 
 	 case SDLK_t:LoggingActive = !LoggingActive;
 		     if(CurGame->Debugger->SetLogFunc)

--- a/mednafen/src/drivers/memdebugger.cpp
+++ b/mednafen/src/drivers/memdebugger.cpp
@@ -27,6 +27,12 @@
 
 #include <trio/trio.h>
 
+extern bool WaitForVSYNC;
+extern bool WaitForHSYNC;
+extern int NeedRun;
+extern void Debugger_GT_ResetHSync(void);
+extern void Debugger_GT_ResetVSync(void);
+
 void MemDebugger::ICV_Init(const char* newcode)
 {
  iconv_t new_ict_game_to_utf8 = (iconv_t)-1, new_ict_utf8_to_game = (iconv_t)-1;
@@ -1234,16 +1240,35 @@ int MemDebugger::Event(const SDL_Event *event)
 		break;
 
 	 case SDLK_s:
-	        if(SizeCache[CurASpace] > (1 << 24))
-                {
-                 error_string = trio_aprintf(_("Address space is too large to search!"));
-                 error_time = -1;
-                }
-		else
+		if(event->key.keysym.mod & KMOD_CTRL)
+	        {
+	         Debugger_GT_ResetVSync();
+	         Debugger_GT_ResetHSync();
+	         WaitForHSYNC = false;
+	         WaitForVSYNC = true;
+	         NeedRun = true;
+	        }
+	        else if(event->key.keysym.mod & KMOD_SHIFT)
+	        {
+	         Debugger_GT_ResetVSync();
+	         Debugger_GT_ResetHSync();
+	         WaitForHSYNC = true;
+	         WaitForVSYNC = false;
+	         NeedRun = true;
+	        }
+	        else
 		{
-		 InPrompt = ByteStringSearch;
-		 myprompt = new MemDebuggerPrompt(this, "Byte String Search", BSS_String);
-		 PromptTAKC = event->key.keysym.sym;
+	         if(SizeCache[CurASpace] > (1 << 24))
+                 {
+                  error_string = trio_aprintf(_("Address space is too large to search!"));
+                  error_time = -1;
+                 }
+		 else
+		 {
+		  InPrompt = ByteStringSearch;
+		  myprompt = new MemDebuggerPrompt(this, "Byte String Search", BSS_String);
+		  PromptTAKC = event->key.keysym.sym;
+		 }
 		}
 		break;
 


### PR DESCRIPTION
In the same way as <Shift>-s will advance by a scanline, and <CTRL>-s will advance by a frame in the main 'disassembler' debugger window, this is now extended to the graphics viewer, the memory viewer, and the log viewer windows.