### PR TITLE
Make MWR timing optional (default off) (cfg "pce.mwrtiming_approx")

### DIFF
--- a/mednafen/src/pce/pce.cpp
+++ b/mednafen/src/pce/pce.cpp
@@ -438,6 +438,8 @@ static MDFN_COLD int LoadCommon(void)
 
  vce = new VCE(IsSGX, vram_size);
  vce->SetVDCUnlimitedSprites(MDFN_GetSettingB("pce.nospritelimit"));
+ vce->SetMWRTiming(MDFN_GetSettingB("pce.mwrtiming_approx"));
+
 
  if(IsSGX)
   MDFN_printf("SuperGrafx Emulation Enabled.\n");
@@ -1104,6 +1106,9 @@ static const MDFNSetting PCESettings[] =
 
   { "pce.nospritelimit", MDFNSF_NOFLAGS, gettext_noop("Remove 16-sprites-per-scanline hardware limit."), 
 					 gettext_noop("WARNING: Enabling this option may cause undesirable graphics glitching on some games(such as \"Bloody Wolf\")."), MDFNST_BOOL, "0" },
+
+  { "pce.mwrtiming_approx", MDFNSF_NOFLAGS, gettext_noop("Approximate MWR VRAM access timing during active display"), 
+					 gettext_noop("WARNING: This is an approximation, and is not accurate; sprite prefetch during HBLANK is not simulated either."), MDFNST_BOOL, "0" },
 
   { "pce.cdbios", MDFNSF_EMU_STATE | MDFNSF_CAT_PATH, gettext_noop("Path to the CD BIOS"), NULL, MDFNST_STRING, "syscard3.pce" },
   { "pce.gecdbios", MDFNSF_EMU_STATE | MDFNSF_CAT_PATH, gettext_noop("Path to the GE CD BIOS"), gettext_noop("Games Express CD Card BIOS (Unlicensed)"), MDFNST_STRING, "gecard.pce" },

--- a/mednafen/src/pce/vce.cpp
+++ b/mednafen/src/pce/vce.cpp
@@ -81,7 +81,10 @@ bool VCE::WS_Hook(int32 vdc_cycles)
  {
   while (vdc[chip].ActiveDisplayPenaltyCycles > 0)  // try to make accesses to ActiveDisplayPenaltyCycles as atomic as possible
   {
-   to_steal++;
+   if (mwr_approximate)
+   {
+    to_steal++;
+   }
    vdc[chip].ActiveDisplayPenaltyCycles--;
   }
  }
@@ -147,6 +150,7 @@ VCE::VCE(const bool want_sgfx, const uint32 vram_size)
  }
 
  SetVDCUnlimitedSprites(false);
+ SetMWRTiming(false);
 
  memset(surf_clut, 0, sizeof(surf_clut));
 
@@ -165,6 +169,11 @@ void VCE::SetVDCUnlimitedSprites(const bool nospritelimit)
 {
  for(unsigned chip = 0; chip < chip_count; chip++)
   vdc[chip].SetUnlimitedSprites(nospritelimit);
+}
+
+void VCE::SetMWRTiming(const bool mwr_switch)
+{
+ mwr_approximate = mwr_switch;
 }
 
 VCE::~VCE()

--- a/mednafen/src/pce/vce.h
+++ b/mednafen/src/pce/vce.h
@@ -32,6 +32,7 @@ class VCE final
 	~VCE() MDFN_COLD;
 
 	void SetVDCUnlimitedSprites(const bool nospritelimit);
+	void SetMWRTiming(const bool mwr_flag);
 	void SetShowHorizOS(bool show);
 	void SetLayerEnableMask(uint64 mask);
 
@@ -232,6 +233,8 @@ class VCE final
 	bool FrameDone;
 	bool ShowHorizOS;
 	bool sgfx;
+
+	bool mwr_approximate;  // flag whether to approximate MWR timing round-robin
 
 	bool skipframe;
 	int32 *LW;


### PR DESCRIPTION
While the MWR approximation had the effect of correcting Wonder Momo, it introduced a screen jitter into Sherlock Holmes and may have caused other issues.

Until it is more accurate, I will consider it 'experimental', and make it optional (default off).

Configuration item "pce.mwrtiming_approx"