### PR TITLE
Azerty

### DIFF
--- a/mednafen/src/drivers/gfxdebugger.cpp
+++ b/mednafen/src/drivers/gfxdebugger.cpp
@@ -249,6 +249,7 @@ int GfxDebugger_Event(const SDL_Event *event)
 	RedoSGD();
 	break;
 
+   case SDLK_SEMICOLON:
    case SDLK_PERIOD:
 	LayerPBN[CurLayer]++;
 	RedoSGD();

--- a/mednafen/src/drivers/logdebugger.cpp
+++ b/mednafen/src/drivers/logdebugger.cpp
@@ -241,6 +241,7 @@ int LogDebugger_Event(const SDL_Event *event)
 			 break;
 
 	 case SDLK_RIGHT:
+	 case SDLK_SEMICOLON:
 	 case SDLK_PERIOD: LogGroupSelect(1);
 			   break;
 

--- a/mednafen/src/drivers/memdebugger.cpp
+++ b/mednafen/src/drivers/memdebugger.cpp
@@ -1110,8 +1110,7 @@ int MemDebugger::Event(const SDL_Event *event)
 	//
 	//
 	//
-	const unsigned ks =
-	 (event->key.keysym.scancode == SDL_SCANCODE_GRAVE) ? SDLK_BACKQUOTE : event->key.keysym.sym;
+	const unsigned ks = event->key.keysym.sym;
 
         if(InPrompt)
         {
@@ -1183,7 +1182,7 @@ int MemDebugger::Event(const SDL_Event *event)
 	{
 	 //
 	}
-	else switch(ks) // was switch(event->key.keysym.sym)
+	else switch(event->key.keysym.sym)
 	{
 	 default: break;
 
@@ -1323,7 +1322,6 @@ int MemDebugger::Event(const SDL_Event *event)
 		}
 		break;
 
-	 case SDLK_BACKQUOTE:
 	 case SDLK_INSERT:
 		InEditMode = !InEditMode;
                 Digitnum = ASpace->MaxDigit;

--- a/mednafen/src/drivers/memdebugger.cpp
+++ b/mednafen/src/drivers/memdebugger.cpp
@@ -1110,7 +1110,8 @@ int MemDebugger::Event(const SDL_Event *event)
 	//
 	//
 	//
-	const unsigned ks = event->key.keysym.sym;
+	const unsigned ks =
+	 (event->key.keysym.scancode == SDL_SCANCODE_GRAVE) ? SDLK_BACKQUOTE : event->key.keysym.sym;
 
         if(InPrompt)
         {
@@ -1182,7 +1183,7 @@ int MemDebugger::Event(const SDL_Event *event)
 	{
 	 //
 	}
-	else switch(event->key.keysym.sym)
+	else switch(ks) // was switch(event->key.keysym.sym)
 	{
 	 default: break;
 
@@ -1322,6 +1323,7 @@ int MemDebugger::Event(const SDL_Event *event)
 		}
 		break;
 
+	 case SDLK_BACKQUOTE:
 	 case SDLK_INSERT:
 		InEditMode = !InEditMode;
                 Digitnum = ASpace->MaxDigit;
@@ -1361,6 +1363,7 @@ int MemDebugger::Event(const SDL_Event *event)
 			  InTextArea = false; 
 			break;
 
+	 case SDLK_SEMICOLON:
 	 case SDLK_PERIOD:
 			CurASpace = (CurASpace + 1) % AddressSpaces->size();
 			ASpace = &(*AddressSpaces)[CurASpace];


### PR DESCRIPTION
Add semi-colon key and an alternative to the period key in order to allow some debugging functions to work on AZERTY keyboards.