### PR TITLE
Update pce_psg.cpp -  Update channel 1 frequency cache upon LFO frequency register writes

### DIFF
--- a/mednafen/src/hw_sound/pce_psg/pce_psg.cpp
+++ b/mednafen/src/hw_sound/pce_psg/pce_psg.cpp
@@ -319,6 +319,7 @@ void PCE_PSG::SetRegister(const unsigned int id, const uint32 value)
 
   case PSG_GSREG_LFOFREQ:
 	lfofreq = value & 0xFF;
+	RecalcFreqCache(1);
 	break;
 
   case PSG_GSREG_LFOCTRL:
@@ -581,6 +582,7 @@ void PCE_PSG::Write(int32 timestamp, uint8 A, uint8 V)
         case 0x08: /* LFO frequency */
             lfofreq = V & 0xFF;
 	    //printf("LFO Freq: %02x\n", V);
+	    RecalcFreqCache(1);
             break;
 
         case 0x09: /* LFO trigger and control */


### PR DESCRIPTION
From MDFN 1.31.0 UNSTABLE - "PCE, PC-FX:  Update channel 1 frequency cache upon LFO frequency register writes(the way the channel 1 frequency and LFO frequency are combined is still inaccurate, however, causing frequency update timing granularity to be too high)."