### PR TITLE
Improve PC-FX palette editor

### DIFF
--- a/mednafen/src/debug.h
+++ b/mednafen/src/debug.h
@@ -56,7 +56,8 @@ typedef enum
 typedef enum
 {
  PALETTE_NONE = 0,	// Not a palette
- PALETTE_PCE		// Only one supported so far
+ PALETTE_PCE,
+ PALETTE_PCFX		// Only two supported so far
 } ASpace_PALETTETYPE;	// Still room for more if weird ones come later
 
 //

--- a/mednafen/src/pcfx/king.cpp
+++ b/mednafen/src/pcfx/king.cpp
@@ -1839,7 +1839,7 @@ void KING_Init(void)
   ASpace_Add16(Do16BitGet, Do16BitPut, "vdcsat0", "VDC-A SAT", 8 + 1, 0, true, ENDIAN_LITTLE);  // SATB to show ?
   ASpace_Add16(Do16BitGet, Do16BitPut, "vdcvram1", "VDC-B VRAM", 17, 0, true, ENDIAN_LITTLE);
   ASpace_Add16(Do16BitGet, Do16BitPut, "vdcsat1", "VDC-B SAT", 8 + 1, 0, true, ENDIAN_LITTLE);  // SATB to show ?
-  ASpace_Add(KING_GetAddressSpaceBytes, KING_PutAddressSpaceBytes, "vce", "VCE Palette RAM", 10);
+  ASpace_AddPalette(KING_GetAddressSpaceBytes, KING_PutAddressSpaceBytes, "vce", "VCE Palette RAM", 10, 0, false, 2, ENDIAN_LITTLE, PALETTE_PCFX);
   #endif
 
   SCSICD_Init(SCSICD_PCFX, 3, FXCDDABufs[0]->Buf(), FXCDDABufs[1]->Buf(), 153600 * MDFN_GetSettingUI("pcfx.cdspeed"), 21477273, KING_CDIRQ, KING_StuffSubchannels);


### PR DESCRIPTION
In debug mode, change PC-FX palette editor to show 16-bit values, with a colour swatch in the right-hand side to demonstrate actual colour (based on YUV)