### PR TITLE
Remove incorrect IRQ acknowledge scenario - Fixes #120

### DIFF
--- a/mednafen/src/pce/huc6280.cpp
+++ b/mednafen/src/pce/huc6280.cpp
@@ -751,7 +751,6 @@ uint8 HuC6280::IRQStatusRead(unsigned int address, bool peek)
  {
   case 0:
 	 if(!peek)
-	  IRQEnd(IQTIMER); 
 	 return(IRQMask ^ 0x7);
   case 1: 
 	{

--- a/mednafen/src/pce/huc6280.cpp
+++ b/mednafen/src/pce/huc6280.cpp
@@ -629,7 +629,8 @@ NO_INLINE void HuC6280::RunSub(void)
 	  {
  	   uint32 tmpa = 0;
 
-	   if((IRQlow & IQTIMER & IRQMask) && !IFlagSample) //IRQSample & IQTIMER)
+//	   if((IRQlow & IQTIMER & IRQMask) && !IFlagSample) //IRQSample & IQTIMER)
+	   if((IRQSample & IQTIMER) && !IFlagSample) //IRQSample & IQTIMER)
 	    tmpa = 0xFFFA;
 	   else if(IRQSample & IQIRQ1)
 	    tmpa = 0xFFF8;


### PR DESCRIPTION
TIMER interrupt is supposed to be acknowledged by write to $1403.  Original code was also acknowledging it on reads from $1402, which was not supported by official documentation. Removal of this extraneous acknowledgement seems to fix the issue.