### PR TITLE
Add GitHub CI builds for Windows and Linux + latest MinGW-w64 support.

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -1,0 +1,51 @@
+name: Build
+
+on: [push, pull_request, workflow_dispatch]
+
+permissions:
+  contents: read
+
+jobs:
+  # === Windows (cross-compile via mingw) ===
+  windows:
+    env:
+      SDL2_VERSION: 2.28.2
+      SYSROOT: /usr/x86_64-w64-mingw32/sys-root/mingw
+    runs-on: ubuntu-latest
+    container: fedora:latest
+    steps:
+      - name: Install dependencies
+        run: sudo dnf -y install autoconf automake binutils cpp gcc make pkgconf pkgconf-m4 pkgconf-pkg-config zip unzip git mingw64-gcc mingw64-gcc-c++ mingw64-zlib mingw64-flac mingw64-SDL2 mingw64-win-iconv
+      - uses: actions/checkout@v3
+      - name: Configure
+        run: CPPFLAGS="-DUNICODE=1 -D_UNICODE=1" LDFLAGS="-fstack-protector -static-libstdc++" mednafen/configure --host=x86_64-w64-mingw32 --enable-threads=win32 --disable-alsa --disable-jack --disable-apple2 --disable-gb --disable-gba --disable-nes --disable-sasplay --disable-sms --disable-snes --disable-snes-faust --disable-ssfplay
+      - name: Build
+        run: make -j$(nproc)
+      - name: Package artifact
+        run: mkdir dist && cp src/mednafen.exe $SYSROOT/bin/SDL2.dll $SYSROOT/bin/iconv.dll $SYSROOT/bin/libFLAC-*.dll $SYSROOT/bin/libgcc* $SYSROOT/bin/libogg* $SYSROOT/bin/libssp* $SYSROOT/bin/libwinpthread* $SYSROOT/bin/zlib1.dll mednafen/COPYING dist/
+      - name: Archive artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: Mednafen (Windows)
+          path: dist/*
+
+  # === Linux (Ubuntu 20.04) ===
+  linux:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Upgrade packages
+        run: sudo apt-get update && sudo apt-get -y upgrade
+      - name: Install required dependencies
+        run: sudo apt-get install build-essential pkg-config libasound2-dev libflac-dev libsdl2-dev zip zlib1g-dev
+      - uses: actions/checkout@v3
+      - name: Configure
+        run: mednafen/configure --disable-apple2 --disable-gb --disable-gba --disable-nes --disable-sasplay --disable-sms --disable-snes --disable-snes-faust --disable-ssfplay
+      - name: Build
+        run: make -j$(nproc)
+      - name: Package artifact
+        run: mkdir dist && cp src/mednafen mednafen/COPYING dist/
+      - name: Archive artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: Mednafen (Linux)
+          path: dist/*

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   # === Windows (cross-compile via mingw) ===
-  windows:
+  win64:
     env:
       SDL2_VERSION: 2.28.2
       SYSROOT: /usr/x86_64-w64-mingw32/sys-root/mingw
@@ -30,13 +30,11 @@ jobs:
           path: dist/*
 
   # === Linux (Ubuntu 20.04) ===
-  linux:
+  linux64:
     runs-on: ubuntu-20.04
     steps:
-      - name: Upgrade packages
-        run: sudo apt-get update && sudo apt-get -y upgrade
       - name: Install required dependencies
-        run: sudo apt-get install build-essential pkg-config libasound2-dev libflac-dev libsdl2-dev zip zlib1g-dev
+        run: sudo apt-get update && sudo apt-get install build-essential pkg-config libasound2-dev libflac-dev libsdl2-dev zip zlib1g-dev
       - uses: actions/checkout@v3
       - name: Configure
         run: mednafen/configure --disable-apple2 --disable-gb --disable-gba --disable-nes --disable-sasplay --disable-sms --disable-snes --disable-snes-faust --disable-ssfplay

--- a/mednafen/src/cdrom/CDAFReader_FLAC.cpp
+++ b/mednafen/src/cdrom/CDAFReader_FLAC.cpp
@@ -23,7 +23,15 @@
 #include "CDAFReader.h"
 #include "CDAFReader_FLAC.h"
 
-#include <FLAC/all.h>
+#ifdef __MINGW32__
+// MinGW-w64 does not define _MSC_VER, but libFLAC requires _MSC_VER
+// to properly declare DLL imports/exports.
+# define _MSC_VER 1933
+# include <FLAC/all.h>
+# undef _MSC_VER
+#else
+# include <FLAC/all.h>
+#endif
 
 namespace Mednafen
 {

--- a/mednafen/src/drivers/main.cpp
+++ b/mednafen/src/drivers/main.cpp
@@ -1990,7 +1990,18 @@ static bool MSW_GetArgcArgv(int *argc, char ***argv)
 extern "C"
 {
  void __set_app_type(int);
+ extern int __mingw_app_type;
  extern int mingw_app_type;
+}
+
+static INLINE void set_mingw_app_type(int value)
+{
+#if __MINGW64_VERSION_MAJOR >= 10
+	// https://github.com/mirror/mingw-w64/commit/973b932e2da39f80ecbd25b8f0973c5fd82fafa3
+	__mingw_app_type = value;
+#else
+	mingw_app_type = value;
+#endif
 }
 
 __attribute__((force_align_arg_pointer))	// Not sure what's going on to cause this to be needed.
@@ -2011,12 +2022,12 @@ int main(int argc, char *argv[])
 	 if(SuppressErrorPopups)
 	 {
 	  __set_app_type(1);
-	  mingw_app_type = 0;
+	  set_mingw_app_type(0);
 	 }
 	 else
 	 {
 	  __set_app_type(2);
-	  mingw_app_type = 1;
+	  set_mingw_app_type(1);
 	 }
 #endif
 	}

--- a/mednafen/src/drivers/main.cpp
+++ b/mednafen/src/drivers/main.cpp
@@ -1762,8 +1762,14 @@ void PrintSDLVersion(void)
  }
 }
 
-#ifdef HAVE_LIBFLAC
- #include <FLAC/all.h>
+#ifdef __MINGW32__
+// MinGW-w64 does not define _MSC_VER, but libFLAC requires _MSC_VER
+// to properly declare DLL imports/exports.
+# define _MSC_VER 1933
+# include <FLAC/all.h>
+# undef _MSC_VER
+#else
+# include <FLAC/all.h>
 #endif
 
 void PrintLIBFLACVersion(void)


### PR DESCRIPTION
This PR accomplishes the following two things:

- Adds GitHub CI builds for Windows and Linux. Some cores are disabled by default, listed in the `.yml` file. One issue is that the binaries are a bit large, though (100MB+, compressed to ~30-40MB for download) - should they be stripped for CI builds, or not?
- Fixes Mednafen builds for new MinGW/MSYS2 versions. This is done with the following two patches:
  - [Fix mingw_app_type initialization on MinGW-w64 10.0.0+.](https://github.com/pce-devel/mednafenPceDev/commit/21b2f45337f0ad16ba32b491f4037fbdd6133da5) - this is a rename done to an internal MinGW symbol around mid-2021. Mednafen has been adjusted to support both.
  - [Work around libFLAC incompatibility with newer MinGW-w64 versions.](https://github.com/pce-devel/mednafenPceDev/commit/956cf7f7911da72be5bb41fba7e16a9753d21d6a) - libFLAC incorrectly limits DLL import/export specification to MSVC compilers; this may have worked in earlier MinGW-w64 versions, but does not in newer ones. This was submitted as a patch to libFLAC [nine years ago](https://flac-dev.xiph.narkive.com/ryPp268C/make-dllimport-dllexport-attributes-work-with-mingw-and-others), but seemingly got stuck on not supporting all configurations - however, this is sufficient for supporting the Mednafen configuration. This patch *may* need to be adjusted to keep compatibility with old MinGW-w64, though.