### PR TITLE
Fix VU meter data

### DIFF
--- a/mednafen/src/pce/pcecd.cpp
+++ b/mednafen/src/pce/pcecd.cpp
@@ -580,13 +580,13 @@ MDFN_FASTCALL uint8 PCECD_Read(uint32 timestamp, uint32 A, int32 &next_event, co
    case 0x4: ret = _Port[4];
 	     break;
 
-   case 0x5: if(_Port[0x3] & 0x2)
+   case 0x5: if((_Port[0x3] & 0x2) == 0)
 	      ret = RawPCMVolumeCache[1] & 0xff;	// Right
 	     else
 	      ret = RawPCMVolumeCache[0] & 0xff;	// Left
 	     break;
 
-   case 0x6: if(_Port[0x3] & 0x2)
+   case 0x6: if((_Port[0x3] & 0x2) == 0)
 	      ret = ((uint16)RawPCMVolumeCache[1]) >> 8;	// Right
 	     else
 	      ret = ((uint16)RawPCMVolumeCache[0]) >> 8;	// Left

--- a/mednafen/src/pce/pcecd.cpp
+++ b/mednafen/src/pce/pcecd.cpp
@@ -568,7 +568,8 @@ MDFN_FASTCALL uint8 PCECD_Read(uint32 timestamp, uint32 A, int32 &next_event, co
    case 0x2: ret = _Port[2];
 	     break;
 
-   case 0x3: bBRAMEnabled = false;
+   case 0x3: if(!PeekMode)
+               bBRAMEnabled = false;
 
 	     /* switch left/right of digitized cd playback */
 	     ret = _Port[0x3];


### PR DESCRIPTION
While music playback was sent to correct channels, the CD_PCMREAD data was not correct, so the VU meters showed activity on the wrong channels.

(Note: Prior PR "Fix improper CDROM BRAM locking in debugger" should be accepted before this one.)