### PR TITLE
Improve PC Engine SCSI emulation.

### DIFF
--- a/mednafen/src/cdrom/scsicd-pce-commands.inc
+++ b/mednafen/src/cdrom/scsicd-pce-commands.inc
@@ -48,7 +48,7 @@ static void DoNEC_PCE_SAPSP(const uint8 *cdb)
  read_sec = read_sec_start = new_read_sec_start;
  read_sec_end = toc.tracks[100].lba;
 
- seekms = get_pce_cd_seek_ms(head_pos, read_sec, CD_DATA_TRANSFER_RATE);
+ seekms = get_pce_cd_seek_ms(head_pos, read_sec);
  //printf("From sec %6.6X to %6.6X (SAPSP), ms = %.2f\n", head_pos, read_sec, seekms);
  CDDASeekTimer = (uint64)(System_Clock * seekms / 1000);
  CDAudioDelay  = (uint64)(System_Clock * 260 / 1000);
@@ -263,6 +263,7 @@ static void DoNEC_PCE_GETDIRINFO(const uint8 *cdb)
     data_in[1] = U8_to_BCD(s);
     data_in[2] = U8_to_BCD(f);
     data_in[3] = toc.tracks[track].control;
+
     data_in_size = 4;
    }
    break;

--- a/mednafen/src/cdrom/scsicd.cpp
+++ b/mednafen/src/cdrom/scsicd.cpp
@@ -214,6 +214,7 @@ static int32 CDAudioDelay;  // not added into savestates
 static uint32 SectorAddr;
 static uint32 SectorCount;
 static uint32 SectorIndex;
+static uint32 PrevHeadAddress;
 static uint32 PrevSectorCount;
 static bool AllowThrottling = false;
 static bool Throttle120KBps = false;
@@ -267,6 +268,7 @@ static void VirtualReset(void)
  din->Flush();
 
  CDReadTimer = 0;
+ Throttle120KBps = false;
 
  head_pos = 0;
  CDDASeekTimer = 0;
@@ -277,7 +279,7 @@ static void VirtualReset(void)
 
  pce_lastsapsp_timestamp = monotonic_timestamp;
 
- PrevSectorCount = SectorAddr = SectorCount = SectorIndex = 0;
+ PrevHeadAddress = PrevSectorCount = SectorAddr = SectorCount = SectorIndex = 0;
  read_sec_start = read_sec = 0;
  read_sec_end = ~0;
 
@@ -1982,17 +1984,13 @@ static void DoREADBase(uint32 sa, uint32 sc)
   return;
  }
 
- if(SCSILog)
+ if(WhichSystem == SCSICD_PCE)
  {
-  int Track = toc.FindTrackByLBA(sa);
-  uint32 Offset = sa - toc.tracks[Track].lba; //Cur_CDIF->GetTrackStartPositionLBA(Track);
-  SCSILog("SCSI", "%sRead: start=0x%08x(track=%d, offs=0x%08x), cnt=0x%08x", (SectorAddr == sa) ? "Sequential" : "", sa, Track, Offset, sc);
- }
+  int32 lastread_ms = (((int64) CDReadTimer * 1000) / System_Clock);
 
- if (WhichSystem == SCSICD_PCE)
- {
-  seekms = get_pce_cd_seek_ms(head_pos, sa, CD_DATA_TRANSFER_RATE);
+  seekms = get_pce_cd_seek_ms(head_pos, sa);
   //printf("From sec %6.6X to %6.6X (dat), ms = %.2f\n", head_pos, sa, seekms);
+  //printf("lastread_ms is %d\n", lastread_ms);
 
   // Sherlock Holmes Consulting Detective videos start with an 8 sector read
   // of ADPCM data, followed by sequential reads of 252 sectors.
@@ -2005,35 +2003,75 @@ static void DoREADBase(uint32 sa, uint32 sc)
   //
   // That is *really* hard to emulate accurately, so instead the code limits
   // the data rate to 120KB/s by adding a delay every 6 sectors.
-
-  if (Throttle120KBps)
+  if(Throttle120KBps && sa != SectorAddr)
   {
-   if (sa == SectorAddr && sc == 252)
-    CDReadTimer += 0; // Streaming time is updated in SCSICD_Run!
+   if(SCSILog)
+    SCSILog("SCSI", "Sherlock Holmes 120KB/s throttling deactivated");
+   Throttle120KBps = false;
+  }
+
+  // If we're already throttling to 120KB/s, then do NOT change CDReadTimer
+  // when a new read is started, just use the old value from the last read.
+  if(!Throttle120KBps)
+  {
+   // Detect Sherlock Holmes's video playback read pattern ...
+   //  Read   6-sector video data at movie start LBA
+   //  Read   8-sector ADPCM data at movie start LBA-8
+   //  Read 252-sector video data at movie start LBA
+   if(AllowThrottling && sc == 252 && PrevSectorCount == 8 && sa == SectorAddr && sa == (PrevHeadAddress - 6))
+   {
+    if(SCSILog)
+     SCSILog("SCSI", "Sherlock Holmes 120KB/s throttling activated");
+    Throttle120KBps = true;
+    CDReadTimer = ((uint64) System_Clock * seekms) / 1000;
+   }
+   else if((sa == SectorAddr) && (lastread_ms > -110) && (lastread_ms < -55))
+   {
+    // This is a nasty game-specific-hack to tune sequential read commands so
+    // that Sherlock Holmes's video does not de-sync while trying to simulate
+    // the FIFO-not-empty delays that the playback relies upon.
+    //
+    // The interaction between these two delays are complex, and also seem to
+    // to depend upon things like the emulated VDC write timings.
+    //
+    // Using the "AllowThrottling" flag is a much more honest, better looking,
+    // and less-likely-to-break-in-the-future solution to Sherlock's videos!
+    if(SCSILog)
+     SCSILog("SCSI", "QuickSequentialRead: start=0x%08x, cnt=0x%08x, previous=%dms", sa, sc, lastread_ms);
+
+//  // This seems more accurate if considering the disc's rotation, but it does
+//  // not work in practice.
+//  // It seems that our seek timings are too fast at their fastest, and too slow at their slowest.
+//  CDReadTimer += ((uint64) System_Clock * seekms) / 1000;
+
+    // So use a fixed 300ms-since-the-previous-read timing instead, which is what
+    // makes Sherlock's movies happy. This is 22.5 sectors of time so there seems
+    // to be some delays going on in the controller that we don't understand.
+    CDReadTimer -= ((uint64) 1 * 2048 * System_Clock) / CD_DATA_TRANSFER_RATE;
+    CDReadTimer += ((uint64) 300 * System_Clock) / 1000;
+   }
    else
    {
-    CDReadTimer = (uint64)(System_Clock * seekms / 1000);
-    if(SCSILog)
-     SCSILog("SCSI", "SCSICD 120KB/s throttling deactivated");
-    Throttle120KBps = false;
-   }
-  }
-  else
-  {
-   CDReadTimer = (uint64)(System_Clock * seekms / 1000);
-   if (AllowThrottling && PrevSectorCount == 8 && sa == SectorAddr && sc == 252)
-   {
-    if(SCSILog)
-     SCSILog("SCSI", "SCSICD 120KB/s throttling activated");
-    Throttle120KBps = true;
-    CDReadTimer -= (uint64)(6 * System_Clock / 60);
+    // If non-sequential or it's just been a while since the last read.
+    CDReadTimer = ((uint64) System_Clock * seekms) / 1000;
    }
   }
  }
  else
  {
-  CDReadTimer = (uint64)(1 * 2048 * System_Clock / CD_DATA_TRANSFER_RATE);
+  // If this is not SCSICD_PCE (i.e. a PC-FX).
+  CDReadTimer = ((uint64) 1 * 2048 * System_Clock) / CD_DATA_TRANSFER_RATE;
  }
+
+ if(SCSILog)
+ {
+  int Track = toc.FindTrackByLBA(sa);
+  uint32 Offset = sa - toc.tracks[Track].lba; //Cur_CDIF->GetTrackStartPositionLBA(Track);
+  SCSILog("SCSI", "%sRead: start=0x%08x(track=%d, offs=0x%08x), cnt=0x%08x, timer=%dms", (SectorAddr == sa) ? "Sequential" : "", sa, Track, Offset, sc, (int) (((int64) CDReadTimer * 1000) / System_Clock));
+ }
+
+ PrevHeadAddress = SectorAddr;
+ PrevSectorCount = sc;
 
  SectorAddr = sa;
  SectorCount = sc;
@@ -2050,7 +2088,6 @@ static void DoREADBase(uint32 sa, uint32 sc)
   CDReadTimer = 0;
   SendStatusAndMessage(STATUS_GOOD, 0x00);
  }
- PrevSectorCount = SectorCount;
  cdda.CDDAStatus = CDDASTATUS_STOPPED;
 }
 
@@ -2861,13 +2898,15 @@ static INLINE void RunCDDA(uint32 system_timestamp, int32 run_time)
 
 static INLINE void RunCDRead(uint32 system_timestamp, int32 run_time)
 {
- // Allow CDReadTimer to go -ve 0.5s to track the CD-ROM's sector timing
- // for mutliple reads asynchronous to the console's CPU.
- if(CDReadTimer > (int32) - (System_Clock / 2))
+ // Allow CDReadTimer to go -ve 1s to track the CD-ROM's sector timing
+ // for multiple reads asynchronous to the console's CPU.
+ if(CDReadTimer > (int32) - System_Clock)
  {
-  int32 OldCDReadTimer = CDReadTimer;
   CDReadTimer -= run_time;
 
+  // If Throttle120KBps, then reading the next sector can occur when CDReadTimer
+  // is -ve, but normally the FIFO-not-empty condition will push CDReadTimer +ve
+  // again as soon as it goes -ve.
   if(SectorCount && CDReadTimer <= 0)
   {
    if(din->CanWrite() < ((WhichSystem == SCSICD_PCFX) ? 2352 : 2048))	// +96 if we find out the PC-FX can read subchannel data along with raw data too. ;)
@@ -2876,24 +2915,28 @@ static INLINE void RunCDRead(uint32 system_timestamp, int32 run_time)
     // everything *except* the PCE version of Sherlock Holmes, where it happens all
     // of the time, and the game seems to rely on it for throttling the read rate.
     //
-    // It is almost certain that both this method of determining when the condition
-    // occurs, and what the delay is that it causes, are totally incorrect!
-
-    if (OldCDReadTimer > 0 && SectorCount != 0)
+    // N.B. This also happens a lot on the PC-FX, because video streaming begins by
+    // sending a READ for the entire movie length, then it just pauses reading when
+    // its buffer memory is full, and continues reading later on to refill it.
+    if(WhichSystem == SCSICD_PCE)
     {
-     if (SCSILog)
-      SCSILog("SCSI", "SCSICD FIFO not empty when CDReadTime expired, SectorAddr 0x%08x, SectorIndex %d", SectorAddr, SectorIndex);
+     if(!Throttle120KBps)
+     {
+      if(SCSILog)
+       SCSILog("SCSI", "SCSICD FIFO not empty when CDReadTime expired, SectorAddr 0x%08x", SectorAddr);
+
+      // Add a fixed 250ms to the delay, since this is what makes Sherlock's movies happy.
+      // This is 18.75 sectors of time, more than a single rotation of the CD, which means
+      // that something is going on in the controller that we don't understand.
+      CDReadTimer += ((uint64) 250 * System_Clock) / 1000;
+     }
     }
-
-    // Throttled CD-ROM reading accumulates CDReadTimer further down in the code!
-    if (!Throttle120KBps)
+    else
     {
-     if (CD_DATA_TRANSFER_RATE == 153600)
-      // A value which seems plausible for real hardware.
-      CDReadTimer += (uint64) 16 * 2048 * System_Clock / CD_DATA_TRANSFER_RATE;
-     else
-      // A value which makes absolutely no sense.
-      CDReadTimer += (uint64) 1 * 2048 * System_Clock / CD_DATA_TRANSFER_RATE;
+     // A value which makes absolutely no sense, but the PC-FX needs something when it pauses reading a video stream.
+     //
+     // N.B. A test with Team Innocent shows that a more-realistic delay works fine.
+     CDReadTimer += ((uint64) 1 * 2048 * System_Clock) / CD_DATA_TRANSFER_RATE;
     }
    }
    else
@@ -2915,13 +2958,13 @@ static INLINE void RunCDRead(uint32 system_timestamp, int32 run_time)
     {
      CommandCCError(SENSEKEY_ILLEGAL_REQUEST, NSE_END_OF_VOLUME);
     }
-    else if(SectorCount && !Cur_CDIF->ReadRawSector(tmp_read_buf, SectorAddr))	//, SectorAddr + SectorCount))
+    else if(!Cur_CDIF->ReadRawSector(tmp_read_buf, SectorAddr))	//, SectorAddr + SectorCount))
     {
      cd.data_transfer_done = false;
 
      CommandCCError(SENSEKEY_ILLEGAL_REQUEST);
     }
-    else if(SectorCount && ValidateRawDataSector(tmp_read_buf, SectorAddr))
+    else if(ValidateRawDataSector(tmp_read_buf, SectorAddr))
     {
      head_pos = SectorAddr;
 
@@ -2937,21 +2980,21 @@ static INLINE void RunCDRead(uint32 system_timestamp, int32 run_time)
      CDIRQCallback(SCSICD_IRQ_DATA_TRANSFER_READY);
 
      SectorAddr++;
-     SectorIndex++;
      SectorCount--;
 
      if(CurrentPhase != PHASE_DATA_IN)
       ChangePhase(PHASE_DATA_IN);
 
-     CDReadTimer += (uint64) 1 * 2048 * System_Clock / CD_DATA_TRANSFER_RATE;
+     CDReadTimer += ((uint64) 1 * 2048 * System_Clock) / CD_DATA_TRANSFER_RATE;
 
-     if (Throttle120KBps && (SectorIndex % 6) == 0)
+     if(Throttle120KBps && (++SectorIndex == 6))
      {
        // For every 6 sectors at 75 sectors/s, add a 1.5 sector delay to
        // provide an overall 60 sectors/s = 120KB/s.
        // This is simpler than simulating the CD-ROM drive's read-buffer
        // behavior on underruns, and it gives smoother streaming results.
-       CDReadTimer += (uint64) (3 * 2048 / 2) * System_Clock / CD_DATA_TRANSFER_RATE;
+       CDReadTimer += ((uint64) 3 * 2048 / 2 * System_Clock) / CD_DATA_TRANSFER_RATE;
+       SectorIndex = 0;
      }
 
      cd.data_transfer_done = (SectorCount == 0);
@@ -3318,12 +3361,11 @@ void SCSICD_Init(int type, int cdda_time_div, int32* left_hrbuf, int32* right_hr
  if(type == SCSICD_PCFX)
  {
   din = new SimpleFIFO<uint8>(65536);	//4096);
-  AllowThrottling = false;
  }
  else
  {
   din = new SimpleFIFO<uint8>(2048); //8192); //1024); /2048);
-  AllowThrottling = (MDFN_GetSettingB("pce.cdspeed") && MDFN_GetSettingB("pce.cdthrottle"));
+  AllowThrottling = MDFN_GetSettingB("pce.cdthrottle");
  }
 
  WhichSystem = type;

--- a/mednafen/src/cdrom/seektime_pce.cpp
+++ b/mednafen/src/cdrom/seektime_pce.cpp
@@ -57,7 +57,7 @@ static int find_sector_group(int sector_num)
 	return group_index;
 }
 
-float get_pce_cd_seek_ms(int start_sector, int target_sector, unsigned transfer_rate)
+float get_pce_cd_seek_ms(int start_sector, int target_sector)
 {
 	int start_index;
 	int target_index;
@@ -93,17 +93,7 @@ float get_pce_cd_seek_ms(int start_sector, int target_sector, unsigned transfer_
 	// Now, we use the algorithm to determine how long to wait
 	if (abs(target_sector - start_sector) <= 3)
 	{
-		if (transfer_rate == 153600)
-		{
-			// A value which closely matches real hardware.
-			milliseconds = (6 * 1000 / 60) + (float)(sector_list[target_index].rotation_ms * 0.75);
-		}
-		else
-		{
-			// An insanely-short value needed for Mednafen's traditional
-			// method of getting Sherlock Holmes video streaming to work.
-			milliseconds = (2 * 1000 / 60);
-		}
+		milliseconds = (6 * 1000 / 60) + (float)(sector_list[target_index].rotation_ms * 0.75);
 	}
 	else if (abs(target_sector - start_sector) < 7)
 	{

--- a/mednafen/src/cdrom/seektime_pce.h
+++ b/mednafen/src/cdrom/seektime_pce.h
@@ -8,5 +8,5 @@
  ============================================================================
  */
 
-extern float get_pce_cd_seek_ms(int start_sector, int target_sector, unsigned transfer_rate);
+extern float get_pce_cd_seek_ms(int start_sector, int target_sector);
 

--- a/mednafen/src/pce/pce.cpp
+++ b/mednafen/src/pce/pce.cpp
@@ -1125,8 +1125,7 @@ static const MDFNSetting PCESettings[] =
 
   { "pce.vramsize", MDFNSF_EMU_STATE | MDFNSF_UNTRUSTED_SAFE | MDFNSF_SUPPRESS_DOC, gettext_noop("Size of emulated VRAM per VDC in 16-bit words.  DO NOT CHANGE THIS UNLESS YOU KNOW WTF YOU ARE DOING."), NULL, MDFNST_UINT, "32768", "32768", "65536" },
 
-  { "pce.cdspeed", MDFNSF_NOFLAGS, gettext_noop("Emulate full CD-ROM transfer rate."), gettext_noop("Disable to use Mednafen's traditional reduced transfer rate and other hacks needed to get the Sherlock Holmes videos to play correctly."), MDFNST_BOOL, "0" },
-  { "pce.cdthrottle", MDFNSF_NOFLAGS, gettext_noop("Enable CD throttling to 120KB/s when needed."), gettext_noop("When emulating the full CD-ROM transfer rate, this can be enabled to detect and throttle the Sherlock Holmes video playback to stop the audio and video going out of sync."), MDFNST_BOOL, "0" },
+  { "pce.cdthrottle", MDFNSF_NOFLAGS, gettext_noop("Enable Sherlock Holmes best-quality video playback."), gettext_noop("This can be enabled to detect and throttle the Sherlock Holmes video playback to 120KB/s."), MDFNST_BOOL, "0" },
 
   { NULL }
 };

--- a/mednafen/src/pce/pcecd.cpp
+++ b/mednafen/src/pce/pcecd.cpp
@@ -131,7 +131,7 @@ typedef struct
  uint16   Addr;
  uint16   ReadAddr;
  uint16   WriteAddr;
- uint16   LengthCount;
+ uint32   LengthCount;
 
  bool HalfReached;
  bool EndReached;
@@ -277,7 +277,7 @@ uint32 PCECD_GetRegister(const unsigned int id, char *special, const uint32 spec
 	break;
 
   case CD_GSREG_ADPCM_LENGTH:
-	value = ADPCM.LengthCount;
+	value = (ADPCM.LengthCount & 0x10000) ? 0xFFFF : ADPCM.LengthCount;
 	break;
 
   case CD_GSREG_ADPCM_PLAYNIBBLE:
@@ -1183,7 +1183,7 @@ static INLINE void ADPCM_Run(const int32 clocks, const int32 timestamp)
   if(ADPCM.WritePending <= 0)
   {
    ADPCM.HalfReached = (ADPCM.LengthCount < 32768);
-   if(!(ADPCM.LastCmd & 0x10) && ADPCM.LengthCount < 0xFFFF)
+   if(!(ADPCM.LastCmd & 0x10) && ADPCM.LengthCount < 0x1FFFF)
     ADPCM.LengthCount++;
 
    ADPCM.RAM[ADPCM.WriteAddr++] = ADPCM.WritePendingValue;

--- a/mednafen/src/pce/pcecd.cpp
+++ b/mednafen/src/pce/pcecd.cpp
@@ -455,7 +455,7 @@ void PCECD_Init(const PCECD_Settings *settings, void (*irqcb)(bool), double mast
 
 	ADPCMBuf = adbuf;
 
-	SCSICD_Init(SCSICD_PCE, 3, hrbuf_l, hrbuf_r, MDFN_GetSettingB("pce.cdspeed") ? 153600 : 126000, master_clock, CDIRQ, StuffSubchannel);
+	SCSICD_Init(SCSICD_PCE, 3, hrbuf_l, hrbuf_r, 153600, master_clock, CDIRQ, StuffSubchannel);
 
         ADPCM.RAM = new uint8[0x10000];
 

--- a/mednafen/src/pcfx/debug.cpp
+++ b/mednafen/src/pcfx/debug.cpp
@@ -455,14 +455,16 @@ static void CPUHandler(const v810_timestamp_t timestamp, uint32 PC)
    const uint16 sc = PCFX_V810.GetPR(6) & 0xFFFF;
    const char* s = PCFXDBG_ShiftJIS_to_UTF8(sc);
    PCFXDBG_DoLog("ROMFONT", "0x%08x->0xFFF0000C, PR7=0x%08x=%s, PR6=0x%04x = %s", lastPC, pr7, (pr7 > 5) ? "?" : font_sizes[pr7], sc, s);
+#if 0
    for(const char* tmp = s; *tmp; tmp++)
    {
     const char c = *tmp;
 
-    if(c != 0x1B)
+    if(c < 0 || c >= 0x20)
      putchar(c);
    }
    fflush(stdout);
+#endif
   }
   else if(PC == 0xFFF00008)
    DoSyscallLog();


### PR DESCRIPTION
Set the PCE CD transfer rate to a console-accurate 150KB/s.
Implement the PCE's SCSI "abort" processing that Sherlock Holmes's customized CD routines rely upon.
Add the missed-sector and sequential-read delays that the Sherlock Holmes videos need to play back correctly.
Fix the PC-FX hang when aborting video playback (that I introduced last year).
Update the optional pce.cdthrottle 120KB/s-for-Sherlock's-videos behavior to work with the changes above.
