### PR TITLE
 Fix PCFX CD sound ( #174 )

### DIFF
--- a/mednafen/src/pcfx/pcfx.cpp
+++ b/mednafen/src/pcfx/pcfx.cpp
@@ -794,15 +794,15 @@ static MDFN_COLD void LoadCommon(std::vector<CDInterface*> *CDInterfaces)
   //fx_vdc_chips[1] = FXVDC_Init(PCFXIRQ_SOURCE_VDCB, MDFN_GetSettingB("pcfx.nospritelimit"));
  }
 
- if(WantHuC6273)
-  HuC6273_Init();
-
- KING_Init();
-
  RAINBOW_Init(MDFN_GetSettingB("pcfx.rainbow.chromaip"));
  SoundBox_Init(MDFN_GetSettingB("pcfx.adpcm.emulate_buggy_codec"), MDFN_GetSettingB("pcfx.adpcm.suppress_channel_reset_clicks"));
  FXINPUT_Init();
  FXTIMER_Init();
+
+ if(WantHuC6273)
+  HuC6273_Init();
+
+ KING_Init();
 
  SCSICD_SetDisc(true, NULL, true);
 


### PR DESCRIPTION
Revert initialization sequence. Doesn't seem to break anything; it's not clear why I re-arranged it in the first place.